### PR TITLE
We need unsigned chars to store read data

### DIFF
--- a/tcmdrw.c
+++ b/tcmdrw.c
@@ -34,7 +34,7 @@ struct tcmd_data {
 	int baudrate;
 	int fd;
 	int debug;
-	char *buf;
+	unsigned char *buf;
 	int buf_sz;
 	int read;
 };


### PR DESCRIPTION
AT least on x86-64 signed values are sign-extended when printed